### PR TITLE
ENG-56569 geminabox dependency not needed

### DIFF
--- a/viewpoint.gemspec
+++ b/viewpoint.gemspec
@@ -27,6 +27,4 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency  'httpclient'
   s.add_runtime_dependency  'rubyntlm'
   s.add_runtime_dependency  'logging'
-
-  s.add_development_dependency "geminabox"
 end


### PR DESCRIPTION
This was added to allow pushing the gem to the internal gem server. Modified build so it is not needed in the gem.
